### PR TITLE
Add support for HTTP/1.1 blob access backend

### DIFF
--- a/cmd/bbb_frontend/main.go
+++ b/cmd/bbb_frontend/main.go
@@ -74,28 +74,29 @@ func main() {
 	uploader := s3manager.NewUploader(session)
 	uploader.Concurrency = 1
 
-	var smallBlobAccess blobstore.BlobAccess
-	var largeBlobAccess blobstore.BlobAccess
+	var casBlobAccess blobstore.BlobAccess
 	var actionCacheBlobAccess blobstore.BlobAccess
 
 	if *remoteCache == "" {
-		smallBlobAccess = blobstore.NewMetricsBlobAccess(
-			blobstore.NewRedisBlobAccess(
-				redis.NewClient(
-					&redis.Options{
-						Addr: *redisEndpoint,
-						DB:   0,
-					}),
-				util.KeyDigestWithoutInstance),
-			"cas_redis")
 
-		largeBlobAccess = blobstore.NewMetricsBlobAccess(
-			blobstore.NewS3BlobAccess(
-				s3,
-				uploader,
-				aws.String("content-addressable-storage"),
-				util.KeyDigestWithoutInstance),
-			"cas_s3")
+		casBlobAccess = blobstore.NewSizeDistinguishingBlobAccess(
+			blobstore.NewMetricsBlobAccess(
+				blobstore.NewRedisBlobAccess(
+					redis.NewClient(
+						&redis.Options{
+							Addr: *redisEndpoint,
+							DB:   0,
+						}),
+					util.KeyDigestWithoutInstance),
+				"cas_redis"),
+			blobstore.NewMetricsBlobAccess(
+				blobstore.NewS3BlobAccess(
+					s3,
+					uploader,
+					aws.String("content-addressable-storage"),
+					util.KeyDigestWithoutInstance),
+				"cas_s3"),
+			1<<20)
 
 		actionCacheBlobAccess = blobstore.NewMetricsBlobAccess(
 			blobstore.NewRedisBlobAccess(
@@ -107,10 +108,7 @@ func main() {
 				util.KeyDigestWithInstance),
 			"ac_redis")
 	} else {
-		smallBlobAccess = blobstore.NewMetricsBlobAccess(
-			blobstore.NewRemoteBlobAccess(*remoteCache, "cas"),
-			"cas_remote")
-		largeBlobAccess = blobstore.NewMetricsBlobAccess(
+		casBlobAccess = blobstore.NewMetricsBlobAccess(
 			blobstore.NewRemoteBlobAccess(*remoteCache, "cas"),
 			"cas_remote")
 		actionCacheBlobAccess = blobstore.NewMetricsBlobAccess(
@@ -120,11 +118,7 @@ func main() {
 
 	// Storage of content and actions.
 	contentAddressableStorageBlobAccess := blobstore.NewMetricsBlobAccess(
-		blobstore.NewMerkleBlobAccess(
-			blobstore.NewSizeDistinguishingBlobAccess(
-				smallBlobAccess,
-				largeBlobAccess,
-				1<<20)),
+		blobstore.NewMerkleBlobAccess(casBlobAccess),
 		"cas_merkle")
 
 	actionCache := ac.NewBlobAccessActionCache(actionCacheBlobAccess)

--- a/cmd/bbb_frontend/main.go
+++ b/cmd/bbb_frontend/main.go
@@ -58,7 +58,7 @@ func main() {
 	// Web server for metrics and profiling.
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
-		log.Fatal(http.ListenAndServe(":80", nil))
+		log.Fatal(http.ListenAndServe(":8080", nil))
 	}()
 
 	// Create an S3 client. Set the uploader concurrency to 1 to drastically reduce memory usage.
@@ -78,7 +78,7 @@ func main() {
 	var largeBlobAccess blobstore.BlobAccess
 	var actionCacheBlobAccess blobstore.BlobAccess
 
-	if *remoteCache != "" {
+	if *remoteCache == "" {
 		smallBlobAccess = blobstore.NewMetricsBlobAccess(
 			blobstore.NewRedisBlobAccess(
 				redis.NewClient(
@@ -110,7 +110,7 @@ func main() {
 		smallBlobAccess = blobstore.NewMetricsBlobAccess(
 			blobstore.NewRemoteBlobAccess(*remoteCache, "cas"),
 			"cas_remote")
-		smallBlobAccess = blobstore.NewMetricsBlobAccess(
+		largeBlobAccess = blobstore.NewMetricsBlobAccess(
 			blobstore.NewRemoteBlobAccess(*remoteCache, "cas"),
 			"cas_remote")
 		actionCacheBlobAccess = blobstore.NewMetricsBlobAccess(

--- a/cmd/bbb_frontend/main.go
+++ b/cmd/bbb_frontend/main.go
@@ -58,7 +58,7 @@ func main() {
 	// Web server for metrics and profiling.
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
-		log.Fatal(http.ListenAndServe(":8080", nil))
+		log.Fatal(http.ListenAndServe(":80", nil))
 	}()
 
 	// Create an S3 client. Set the uploader concurrency to 1 to drastically reduce memory usage.

--- a/cmd/bbb_scheduler/main.go
+++ b/cmd/bbb_scheduler/main.go
@@ -21,7 +21,7 @@ func main() {
 	// Web server for metrics and profiling.
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
-		log.Fatal(http.ListenAndServe(":8081", nil))
+		log.Fatal(http.ListenAndServe(":80", nil))
 	}()
 
 	buildQueue := builder.NewWorkerBuildQueue(util.KeyDigestWithInstance, 16)

--- a/cmd/bbb_scheduler/main.go
+++ b/cmd/bbb_scheduler/main.go
@@ -21,7 +21,7 @@ func main() {
 	// Web server for metrics and profiling.
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
-		log.Fatal(http.ListenAndServe(":80", nil))
+		log.Fatal(http.ListenAndServe(":8081", nil))
 	}()
 
 	buildQueue := builder.NewWorkerBuildQueue(util.KeyDigestWithInstance, 16)

--- a/cmd/bbb_worker/main.go
+++ b/cmd/bbb_worker/main.go
@@ -30,14 +30,14 @@ import (
 
 func main() {
 	var (
-		redisEndpoint     = flag.String("redis-endpoint", "", "Redis endpoint for the Content Addressable Storage and the Action Cache")
-		
+		redisEndpoint = flag.String("redis-endpoint", "", "Redis endpoint for the Content Addressable Storage and the Action Cache")
+
 		s3Endpoint        = flag.String("s3-endpoint", "", "S3 compatible object storage endpoint for the Content Addressable Storage and the Action Cache")
 		s3AccessKeyId     = flag.String("s3-access-key-id", "", "Access key for the object storage")
 		s3SecretAccessKey = flag.String("s3-secret-access-key", "", "Secret key for the object storage")
 		s3Region          = flag.String("s3-region", "", "Region of the object storage")
 		s3DisableSsl      = flag.Bool("s3-disable-ssl", false, "Whether to use HTTP for the object storage instead of HTTPS")
-		
+
 		remoteCache = flag.String("remote", "", "The address of the remote HTTP cache")
 
 		schedulerAddress = flag.String("scheduler", "", "Address of the scheduler to which to connect")
@@ -65,12 +65,12 @@ func main() {
 	s3 := s3.New(session)
 	uploader := s3manager.NewUploader(session)
 	uploader.Concurrency = 1
-	
+
 	var smallBlobAccess blobstore.BlobAccess
 	var largeBlobAccess blobstore.BlobAccess
 	var actionCacheBlobAccess blobstore.BlobAccess
 
-	if *remoteCache != "" {
+	if *remoteCache == "" {
 		smallBlobAccess = blobstore.NewMetricsBlobAccess(
 			blobstore.NewRedisBlobAccess(
 				redis.NewClient(
@@ -102,7 +102,7 @@ func main() {
 		smallBlobAccess = blobstore.NewMetricsBlobAccess(
 			blobstore.NewRemoteBlobAccess(*remoteCache, "cas"),
 			"cas_remote")
-		smallBlobAccess = blobstore.NewMetricsBlobAccess(
+		largeBlobAccess = blobstore.NewMetricsBlobAccess(
 			blobstore.NewRemoteBlobAccess(*remoteCache, "cas"),
 			"cas_remote")
 		actionCacheBlobAccess = blobstore.NewMetricsBlobAccess(

--- a/cmd/bbb_worker/main.go
+++ b/cmd/bbb_worker/main.go
@@ -31,11 +31,14 @@ import (
 func main() {
 	var (
 		redisEndpoint     = flag.String("redis-endpoint", "", "Redis endpoint for the Content Addressable Storage and the Action Cache")
+		
 		s3Endpoint        = flag.String("s3-endpoint", "", "S3 compatible object storage endpoint for the Content Addressable Storage and the Action Cache")
 		s3AccessKeyId     = flag.String("s3-access-key-id", "", "Access key for the object storage")
 		s3SecretAccessKey = flag.String("s3-secret-access-key", "", "Secret key for the object storage")
 		s3Region          = flag.String("s3-region", "", "Region of the object storage")
 		s3DisableSsl      = flag.Bool("s3-disable-ssl", false, "Whether to use HTTP for the object storage instead of HTTPS")
+		
+		remoteCache = flag.String("remote", "", "The address of the remote HTTP cache")
 
 		schedulerAddress = flag.String("scheduler", "", "Address of the scheduler to which to connect")
 	)
@@ -62,38 +65,59 @@ func main() {
 	s3 := s3.New(session)
 	uploader := s3manager.NewUploader(session)
 	uploader.Concurrency = 1
+	
+	var smallBlobAccess blobstore.BlobAccess
+	var largeBlobAccess blobstore.BlobAccess
+	var actionCacheBlobAccess blobstore.BlobAccess
+
+	if *remoteCache != "" {
+		smallBlobAccess = blobstore.NewMetricsBlobAccess(
+			blobstore.NewRedisBlobAccess(
+				redis.NewClient(
+					&redis.Options{
+						Addr: *redisEndpoint,
+						DB:   0,
+					}),
+				util.KeyDigestWithoutInstance),
+			"cas_redis")
+
+		largeBlobAccess = blobstore.NewMetricsBlobAccess(
+			blobstore.NewS3BlobAccess(
+				s3,
+				uploader,
+				aws.String("content-addressable-storage"),
+				util.KeyDigestWithoutInstance),
+			"cas_s3")
+
+		actionCacheBlobAccess = blobstore.NewMetricsBlobAccess(
+			blobstore.NewRedisBlobAccess(
+				redis.NewClient(
+					&redis.Options{
+						Addr: *redisEndpoint,
+						DB:   1,
+					}),
+				util.KeyDigestWithInstance),
+			"ac_redis")
+	} else {
+		smallBlobAccess = blobstore.NewMetricsBlobAccess(
+			blobstore.NewRemoteBlobAccess(*remoteCache, "cas"),
+			"cas_remote")
+		smallBlobAccess = blobstore.NewMetricsBlobAccess(
+			blobstore.NewRemoteBlobAccess(*remoteCache, "cas"),
+			"cas_remote")
+		actionCacheBlobAccess = blobstore.NewMetricsBlobAccess(
+			blobstore.NewRemoteBlobAccess(*remoteCache, "ac"),
+			"ac_remote")
+	}
 
 	// Storage of content and actions.
 	contentAddressableStorageBlobAccess := blobstore.NewMetricsBlobAccess(
 		blobstore.NewMerkleBlobAccess(
 			blobstore.NewSizeDistinguishingBlobAccess(
-				blobstore.NewMetricsBlobAccess(
-					blobstore.NewRedisBlobAccess(
-						redis.NewClient(
-							&redis.Options{
-								Addr: *redisEndpoint,
-								DB:   0,
-							}),
-						util.KeyDigestWithoutInstance),
-					"cas_redis"),
-				blobstore.NewMetricsBlobAccess(
-					blobstore.NewS3BlobAccess(
-						s3,
-						uploader,
-						aws.String("content-addressable-storage"),
-						util.KeyDigestWithoutInstance),
-					"cas_s3"),
+				smallBlobAccess,
+				largeBlobAccess,
 				1<<20)),
 		"cas_merkle")
-	actionCacheBlobAccess := blobstore.NewMetricsBlobAccess(
-		blobstore.NewRedisBlobAccess(
-			redis.NewClient(
-				&redis.Options{
-					Addr: *redisEndpoint,
-					DB:   1,
-				}),
-			util.KeyDigestWithInstance),
-		"ac_redis")
 
 	// On-disk caching of content for efficient linking into build environments.
 	if err := os.Mkdir("/cache", 0); err != nil {

--- a/pkg/blobstore/BUILD.bazel
+++ b/pkg/blobstore/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "merkle_blob_access.go",
         "metrics_blob_access.go",
         "redis_blob_access.go",
+        "remote_blob_access.go",
         "s3_blob_access.go",
         "size_distinguishing_blob_access.go",
     ],
@@ -24,5 +25,6 @@ go_library(
         "@go_googleapis//google/devtools/remoteexecution/v1test:remoteexecution_go_proto",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
+        "@org_golang_x_net//context/ctxhttp:go_default_library",
     ],
 )

--- a/pkg/blobstore/remote_blob_access.go
+++ b/pkg/blobstore/remote_blob_access.go
@@ -3,9 +3,10 @@ package blobstore
 import (
 	"context"
 	"fmt"
-	"golang.org/x/net/context/ctxhttp"
 	"io"
 	"net/http"
+
+	"golang.org/x/net/context/ctxhttp"
 
 	remoteexecution "google.golang.org/genproto/googleapis/devtools/remoteexecution/v1test"
 	"google.golang.org/grpc/codes"
@@ -17,6 +18,9 @@ type remoteBlobAccess struct {
 	prefix  string
 }
 
+// NewRemoteBlobAccess for use of HTTP/1.1 cache backend.
+//
+// See: https://docs.bazel.build/versions/master/remote-caching.html#http-caching-protocol
 func NewRemoteBlobAccess(address, prefix string) BlobAccess {
 	return &remoteBlobAccess{
 		address: address,
@@ -49,7 +53,6 @@ func (ba *remoteBlobAccess) Put(ctx context.Context, instance string, digest *re
 	if err != nil {
 		return err
 	}
-	// req.ContentLength = digest.GetSizeBytes()
 
 	_, err = ctxhttp.Do(ctx, http.DefaultClient, req)
 	return err

--- a/pkg/blobstore/remote_blob_access.go
+++ b/pkg/blobstore/remote_blob_access.go
@@ -25,7 +25,7 @@ func NewRemoteBlobAccess(address, prefix string) BlobAccess {
 func (ba *remoteBlobAccess) Get(ctx context.Context, instance string, digest *remoteexecution.Digest) io.ReadCloser {
 	resp, err := ctxhttp.Get(ctx, http.DefaultClient, fmt.Sprintf("%s/%s/%s", ba.address, ba.prefix, digest.GetHash()))
 	if err != nil {
-		// todo
+		return &errorReader{err: err}
 	}
 
 	return resp.Body

--- a/pkg/blobstore/remote_blob_access.go
+++ b/pkg/blobstore/remote_blob_access.go
@@ -1,0 +1,54 @@
+package blobstore
+
+import (
+	"context"
+	"fmt"
+	"golang.org/x/net/context/ctxhttp"
+	"io"
+	"net/http"
+
+	remoteexecution "google.golang.org/genproto/googleapis/devtools/remoteexecution/v1test"
+)
+
+type remoteBlobAccess struct {
+	address string
+	prefix  string
+}
+
+func NewRemoteBlobAccess(address, prefix string) BlobAccess {
+	return &remoteBlobAccess{
+		address: address,
+		prefix:  prefix,
+	}
+}
+
+func (ba *remoteBlobAccess) Get(ctx context.Context, instance string, digest *remoteexecution.Digest) io.ReadCloser {
+	resp, err := ctxhttp.Get(ctx, http.DefaultClient, fmt.Sprintf("%s/%s/%s", ba.address, ba.prefix, digest.GetHash()))
+	if err != nil {
+		// todo
+	}
+
+	return resp.Body
+}
+
+func (ba *remoteBlobAccess) Put(ctx context.Context, instance string, digest *remoteexecution.Digest, r io.ReadCloser) error {
+	_, err := ctxhttp.Post(ctx, http.DefaultClient, fmt.Sprintf("%s/%s/%s", ba.address, ba.prefix, digest.GetHash()), "todo-body-type", r)
+
+	return err
+}
+
+func (ba *remoteBlobAccess) FindMissing(ctx context.Context, instance string, digests []*remoteexecution.Digest) ([]*remoteexecution.Digest, error) {
+	var missing []*remoteexecution.Digest
+	for _, digest := range digests {
+		url := fmt.Sprintf("%s/%s/%s", ba.address, ba.prefix, digest.GetHash())
+		resp, err := ctxhttp.Head(ctx, http.DefaultClient, url)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != 200 {
+			missing = append(missing, digest)
+		}
+	}
+	return missing, nil
+}


### PR DESCRIPTION
I was trying this out with https://github.com/buchgr/bazel-remote, but it could also be used with nginx or another HTTP service that allows GET and PUT of objects. 

I'm also having problems when cache entries are missing. I saw this TODO
https://github.com/EdSchouten/bazel-buildbarn/blob/6c9536a1572ba760ded37b59e63e93c82d3d188c/pkg/builder/local_build_executor.go#L68

Is it expected to fail when data is missing from the CAS? 

I believe this works. I was never able to get the executor to actually execute anything, but it did return cached values. 