### PR TITLE
Add support for ActionCache::UpdateActionResult().

### DIFF
--- a/cmd/bbb_frontend/main.go
+++ b/cmd/bbb_frontend/main.go
@@ -42,6 +42,8 @@ func (i *stringList) Set(value string) error {
 func main() {
 	var schedulersList stringList
 	var (
+		actionCacheAllowUpdates = flag.Bool("ac-allow-updates", false, "Allow clients to write into the action cache")
+
 		redisEndpoint = flag.String("redis-endpoint", "", "Redis endpoint for the Content Addressable Storage and the Action Cache")
 
 		s3Endpoint        = flag.String("s3-endpoint", "", "S3 compatible object storage endpoint for the Content Addressable Storage and the Action Cache")
@@ -147,7 +149,7 @@ func main() {
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 	)
-	remoteexecution.RegisterActionCacheServer(s, ac.NewActionCacheServer(actionCache))
+	remoteexecution.RegisterActionCacheServer(s, ac.NewActionCacheServer(actionCache, *actionCacheAllowUpdates))
 	remoteexecution.RegisterContentAddressableStorageServer(s, cas.NewContentAddressableStorageServer(contentAddressableStorageBlobAccess))
 	bytestream.RegisterByteStreamServer(s, blobstore.NewByteStreamServer(contentAddressableStorageBlobAccess))
 	remoteexecution.RegisterExecutionServer(s, buildQueue)


### PR DESCRIPTION
Bazel can be configured to fall back to local builds in case remote
builds fail. They may also be configured to push such results into the
remote action cache. Leave this functionality disabled by default, as
there may be setups for which this is not desired.

At the same time, correct the error code that is returned when this
functionality is disabled. The protocol specification documents that
UNIMPLEMENTED is returned instead of PERMISSION_DENIED.