### PR TITLE
Implementing automatic repairing of CAS inconsistencies.

### DIFF
--- a/pkg/blobstore/blob_access.go
+++ b/pkg/blobstore/blob_access.go
@@ -13,6 +13,7 @@ import (
 type BlobAccess interface {
 	Get(ctx context.Context, instance string, digest *remoteexecution.Digest) io.ReadCloser
 	Put(ctx context.Context, instance string, digest *remoteexecution.Digest, sizeBytes int64, r io.ReadCloser) error
+	Delete(ctx context.Context, instance string, digest *remoteexecution.Digest) error
 	FindMissing(ctx context.Context, instance string, digests []*remoteexecution.Digest) ([]*remoteexecution.Digest, error)
 }
 

--- a/pkg/blobstore/metrics_blob_access.go
+++ b/pkg/blobstore/metrics_blob_access.go
@@ -65,6 +65,14 @@ func (ba *metricsBlobAccess) Put(ctx context.Context, instance string, digest *r
 	return err
 }
 
+func (ba *metricsBlobAccess) Delete(ctx context.Context, instance string, digest *remoteexecution.Digest) error {
+	blobAccessOperationsStartedTotal.WithLabelValues(ba.name, "Delete").Inc()
+	timeStart := time.Now()
+	err := ba.blobAccess.Delete(ctx, instance, digest)
+	blobAccessOperationsDurationSeconds.WithLabelValues(ba.name, "Delete").Observe(time.Now().Sub(timeStart).Seconds())
+	return err
+}
+
 func (ba *metricsBlobAccess) FindMissing(ctx context.Context, instance string, digests []*remoteexecution.Digest) ([]*remoteexecution.Digest, error) {
 	blobAccessOperationsStartedTotal.WithLabelValues(ba.name, "FindMissing").Inc()
 	timeStart := time.Now()

--- a/pkg/blobstore/redis_blob_access.go
+++ b/pkg/blobstore/redis_blob_access.go
@@ -62,6 +62,14 @@ func (ba *redisBlobAccess) Put(ctx context.Context, instance string, digest *rem
 	return ba.redisClient.Set(key, value, 0).Err()
 }
 
+func (ba *redisBlobAccess) Delete(ctx context.Context, instance string, digest *remoteexecution.Digest) error {
+	key, err := ba.blobKeyer(instance, digest)
+	if err != nil {
+		return err
+	}
+	return ba.redisClient.Del(key).Err()
+}
+
 func (ba *redisBlobAccess) FindMissing(ctx context.Context, instance string, digests []*remoteexecution.Digest) ([]*remoteexecution.Digest, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/pkg/blobstore/remote_blob_access.go
+++ b/pkg/blobstore/remote_blob_access.go
@@ -2,7 +2,6 @@ package blobstore
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -64,7 +63,7 @@ func (ba *remoteBlobAccess) Put(ctx context.Context, instance string, digest *re
 }
 
 func (ba *remoteBlobAccess) Delete(ctx context.Context, instance string, digest *remoteexecution.Digest) error {
-	return errors.New("Bazel HTTP caching protocol does not support object deletion")
+	return status.Error(codes.Unimplemented, "Bazel HTTP caching protocol does not support object deletion")
 }
 
 func (ba *remoteBlobAccess) FindMissing(ctx context.Context, instance string, digests []*remoteexecution.Digest) ([]*remoteexecution.Digest, error) {

--- a/pkg/blobstore/remote_blob_access.go
+++ b/pkg/blobstore/remote_blob_access.go
@@ -2,6 +2,7 @@ package blobstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -60,6 +61,10 @@ func (ba *remoteBlobAccess) Put(ctx context.Context, instance string, digest *re
 	req.ContentLength = sizeBytes
 	_, err = ctxhttp.Do(ctx, http.DefaultClient, req)
 	return err
+}
+
+func (ba *remoteBlobAccess) Delete(ctx context.Context, instance string, digest *remoteexecution.Digest) error {
+	return errors.New("Bazel HTTP caching protocol does not support object deletion")
 }
 
 func (ba *remoteBlobAccess) FindMissing(ctx context.Context, instance string, digests []*remoteexecution.Digest) ([]*remoteexecution.Digest, error) {

--- a/pkg/blobstore/s3_blob_access.go
+++ b/pkg/blobstore/s3_blob_access.go
@@ -73,6 +73,18 @@ func (ba *s3BlobAccess) Put(ctx context.Context, instance string, digest *remote
 	return convertS3Error(err)
 }
 
+func (ba *s3BlobAccess) Delete(ctx context.Context, instance string, digest *remoteexecution.Digest) error {
+	key, err := ba.blobKeyer(instance, digest)
+	if err != nil {
+		return err
+	}
+	_, err = ba.s3.DeleteObjectWithContext(ctx, &s3.DeleteObjectInput{
+		Bucket: ba.bucketName,
+		Key:    &key,
+	})
+	return convertS3Error(err)
+}
+
 func (ba *s3BlobAccess) FindMissing(ctx context.Context, instance string, digests []*remoteexecution.Digest) ([]*remoteexecution.Digest, error) {
 	var missing []*remoteexecution.Digest
 	for _, digest := range digests {

--- a/pkg/blobstore/size_distinguishing_blob_access.go
+++ b/pkg/blobstore/size_distinguishing_blob_access.go
@@ -42,6 +42,13 @@ func (ba *sizeDistinguishingBlobAccess) Put(ctx context.Context, instance string
 	return ba.largeBlobAccess.Put(ctx, instance, digest, sizeBytes, r)
 }
 
+func (ba *sizeDistinguishingBlobAccess) Delete(ctx context.Context, instance string, digest *remoteexecution.Digest) error {
+	if digest.SizeBytes <= ba.cutoffSizeBytes {
+		return ba.smallBlobAccess.Delete(ctx, instance, digest)
+	}
+	return ba.largeBlobAccess.Delete(ctx, instance, digest)
+}
+
 type findMissingResults struct {
 	missing []*remoteexecution.Digest
 	err     error


### PR DESCRIPTION
I've observed cases where the CAS of a build cluster may become
corrupted. For example, S3 backend implementations that leave partially
completed uploads lying around. The Merkle blob access already allows
detecting those cases, but only causes access to the blob to abort.

Extend the Merkle blob access to send an additional delete request to
the storage backend, so that the build cluster doesn't end up in a
broken state indefinitely. If a client now needs to repeat an execute
request due to data corruption, it will properly observe that CAS
entries have become missing, so that they are re-uploaded by the client.