### PR TITLE
Make sure PWD is as expected

### DIFF
--- a/deployments/bare/run.sh
+++ b/deployments/bare/run.sh
@@ -15,16 +15,13 @@
 
 set -eux
 
+cd "$(dirname "$0")"
+
 # Golang architecture of the current system.
 ARCH="$(uname | tr '[A-Z]' '[a-z]')_amd64_pure_stripped"
-# Location of this script
-SCRIPT_DIR="$(dirname "$0")"
 # Location where the Buildbarn source tree is stored.
-BBB_SRC="$(realpath "${SCRIPT_DIR}/../..")"
+BBB_SRC="$(pwd)/../.."
 
-if [[ "${PWD}" != "${SCRIPT_DIR}" ]]; then
-    cd "${SCRIPT_DIR}"
-fi
 CURWD="$(pwd)"
 trap 'kill $(jobs -p)' EXIT TERM INT
 

--- a/deployments/bare/run.sh
+++ b/deployments/bare/run.sh
@@ -17,9 +17,14 @@ set -eux
 
 # Golang architecture of the current system.
 ARCH="$(uname | tr '[A-Z]' '[a-z]')_amd64_pure_stripped"
+# Location of this script
+SCRIPT_DIR="$(dirname "$0")"
 # Location where the Buildbarn source tree is stored.
-BBB_SRC="$(pwd)/../.."
+BBB_SRC="$(realpath "${SCRIPT_DIR}/../..")"
 
+if [[ "${PWD}" != "${SCRIPT_DIR}" ]]; then
+    cd "${SCRIPT_DIR}"
+fi
 CURWD="$(pwd)"
 trap 'kill $(jobs -p)' EXIT TERM INT
 


### PR DESCRIPTION
The script `deployments/bare/run.sh` assumes it is invoked from the directory `deployments/bare`.

This pull requests removes this assumption by checking if `pwd` is as expected and changing into directory the right directory if not.